### PR TITLE
OpenGD77 Timeslot Override

### DIFF
--- a/src/dzcb/farnsworth.py
+++ b/src/dzcb/farnsworth.py
@@ -45,12 +45,10 @@ GroupList_name_maps = dict(
 
 
 def GroupList_to_dict(g):
-    d = {
-        GroupList_name_maps[k]: v
-        for k, v in attr.asdict(g).items()
-        if k in attr.fields_dict(GroupList)
+    return {
+        "Name": g.name,
+        "Contact": [tg.name for tg in g.contacts]
     }
-    return d
 
 
 def ScanList_to_dict(s):

--- a/src/dzcb/gb3gf.py
+++ b/src/dzcb/gb3gf.py
@@ -84,6 +84,7 @@ def Codeplug_to_gb3gf_opengd77_csv(cp, output_dir):
                     "RX Tone": "None",
                     "TX Tone": "None",
                     "Colour Code": channel.color_code,
+                    "Contact": "N/A",
                     "TG List": channel.grouplist.name if channel.grouplist else "None",
                 }
                 if channel.talkgroup:

--- a/src/dzcb/k7abd.py
+++ b/src/dzcb/k7abd.py
@@ -73,7 +73,7 @@ def Codeplug_from_zone_dicts(zone_dicts):
         contacts.update(ch.static_talkgroups)
         grouplist = GroupList(
             name="{} TGS".format(ch.code),
-            contacts=[tg.name for tg in ch.static_talkgroups],
+            contacts=ch.static_talkgroups,
         )
         grouplists.append(grouplist)
         return attr.evolve(ch, grouplist=grouplist)


### PR DESCRIPTION
uniquifying contacts for anytone 868 support broke opengd77 support.

allow opengd77 to use `talkgroup_with_timeslot` throughout to create duplicate contact IDs with different timeslot override and apply these throughout the opengd77 codeplug