### PR TITLE
dzcb.repeaterbook: limit default states

### DIFF
--- a/src/dzcb/repeaterbook.py
+++ b/src/dzcb/repeaterbook.py
@@ -22,10 +22,10 @@ REPEATERBOOK_API = "https://www.repeaterbook.com/api/export.php"
 REPEATERBOOK_API_DELAY = 30
 REPEATERBOOK_LAST_FETCH = 0
 
-# XXX: Repeaterbook API returns 3500 records per request,
-#      so limit the data to the area of interest. Eventually
-#      this list will be passed by JSON or CSV
-REPEATERBOOK_DEFAULT_STATES = ("Washington","Oregon","Idaho","California","British Columbia")
+# Limit default state to avoid unnecessary API hits
+# Users will want to pass the state on the command line
+# TODO: Geocode Lat/Long from the CSV file
+REPEATERBOOK_DEFAULT_STATES = ("Washington","Oregon")
 REPEATERBOOK_CACHE_MAX_AGE = 3600 * 12.1  # 12 hours (and some change)
 CSV_ZONE_NAME = "Zone Name"
 CSV_LAT = "Lat"


### PR DESCRIPTION
Limit default states to Washington and Oregon, since this is the region where I live and the RPB
API delay is 30 seconds.

So avoid a long wait for 5 * 30 seconds if someone forgets to pass the state... maybe there shouldn't even be a default for this value?

Add a TODO about figuring out a smart default.

For the time being, users will probably pass the states of interest on the command line (generate.sh)