### PR TITLE
Stable IDs for ScanList and GroupList

### DIFF
--- a/codeplug/default/profile.sh
+++ b/codeplug/default/profile.sh
@@ -9,5 +9,5 @@ python -m cProfile -o $OUTPUT/profile -m dzcb \
     --repeaterbook-state washington oregon \
     --repeaterbook-proximity-csv "$DIR/../../src/dzcb/data/repeaterbook_proximity_zones.csv" \
     --scanlists-json $DIR/scanlists.json \
-    --order order.csv -- \
+    --order $DIR/order.csv -- \
 $OUTPUT/default

--- a/src/dzcb/anytone.py
+++ b/src/dzcb/anytone.py
@@ -404,7 +404,7 @@ def DigitalChannel_to_dict(channel):
     return d
 
 
-def Channel_to_dict(index, channel):
+def Channel_to_dict(index, channel, codeplug):
     d = {
         "No.": str(index + 1),
         "Channel Name": channel.short_name,
@@ -414,7 +414,7 @@ def Channel_to_dict(index, channel):
         "Transmit Power": str(channel.power),
         "Band Width": "25K" if channel.bandwidth > 19 else "12.5K",
         "PTT Prohibit": value_replacements[channel.rx_only],
-        "Scan List": channel.scanlist,
+        "Scan List": channel.scanlist_name(codeplug),
     }
     if isinstance(channel, AnalogChannel):
         d.update(AnalogChannel_to_dict(channel))
@@ -482,7 +482,7 @@ def Codeplug_to_anytone_csv(cp, output_dir, models=None):
             csvw.writeheader()
             for ix, channel in enumerate(mcp.channels):
                 d = model["channel"].copy()
-                d.update(Channel_to_dict(ix, channel))
+                d.update(Channel_to_dict(ix, channel, mcp))
                 csvw.writerow(replace_field_names(remove_fields(d, model), model))
         with (radio_dir / model["zone_filename"]).open("w", newline="") as f:
             csvw = csv.DictWriter(f, tuple(model["zone"].keys()))

--- a/src/dzcb/farnsworth.py
+++ b/src/dzcb/farnsworth.py
@@ -127,12 +127,12 @@ AnalogChannel_name_maps = dict(
 )
 
 
-def AnalogChannel_to_dict(c):
+def AnalogChannel_to_dict(c, codeplug):
     d = DefaultChannel.copy()
     d.update(
         {
             "ChannelMode": "Analog",
-            "ScanList": dzcb.munge.zone_name(c.scanlist, NAME_MAX),
+            "ScanList": dzcb.munge.zone_name(c.scanlist_name(codeplug), NAME_MAX),
         }
     )
     d.update(
@@ -168,15 +168,15 @@ DigitalChannel_name_maps = dict(
 )
 
 
-def DigitalChannel_to_dict(c):
+def DigitalChannel_to_dict(c, codeplug):
     d = DefaultChannel.copy()
     d.update(
         {
             "ChannelMode": "Digital",
             "RepeaterSlot": str(c.talkgroup.timeslot) if c.talkgroup else 1,
             "ContactName": str(c.talkgroup.name) if c.talkgroup else "Parrot 1",
-            "GroupList": str(c.grouplist.name) if c.grouplist else None,
-            "ScanList": dzcb.munge.zone_name(c.scanlist, NAME_MAX),
+            "GroupList": str(c.grouplist_name(codeplug)) if c.grouplist else None,
+            "ScanList": dzcb.munge.zone_name(c.scanlist_name(codeplug), NAME_MAX),
         }
     )
     d.update(
@@ -197,12 +197,12 @@ Channel_value_replacements = {
 }
 
 
-def Channel_to_dict(c):
+def Channel_to_dict(c, codeplug):
     d = None
     if isinstance(c, AnalogChannel):
-        d = AnalogChannel_to_dict(c)
+        d = AnalogChannel_to_dict(c, codeplug)
     elif isinstance(c, DigitalChannel):
-        d = DigitalChannel_to_dict(c)
+        d = DigitalChannel_to_dict(c, codeplug)
     if d is None:
         raise ValueError("Unknown type: {}".format(c))
     return {k: Channel_value_replacements.get(v, str(v)) for k, v in d.items()}
@@ -236,7 +236,7 @@ def Codeplug_to_json(cp, based_on=None):
                 Contact_to_dict(c)
                 for c in uniquify_contacts(cp.contacts, key=lambda ct: ct.name)
             ],
-            Channels=[Channel_to_dict(c) for c in cp.channels],
+            Channels=[Channel_to_dict(c, cp) for c in cp.channels],
             GroupLists=[GroupList_to_dict(c) for c in cp.grouplists],
             ScanLists=[ScanList_to_dict(c) for c in cp.scanlists],
             Zones=[Zone_to_dict(c) for c in cp.zones],

--- a/src/dzcb/gb3gf.py
+++ b/src/dzcb/gb3gf.py
@@ -85,7 +85,7 @@ def Codeplug_to_gb3gf_opengd77_csv(cp, output_dir):
                     "TX Tone": "None",
                     "Colour Code": channel.color_code,
                     "Contact": "N/A",
-                    "TG List": channel.grouplist.name if channel.grouplist else "None",
+                    "TG List": channel.grouplist_name(cp) if channel.grouplist else "None",
                 }
                 if channel.talkgroup:
                     d["Contact"] = channel.talkgroup.name_with_timeslot

--- a/src/dzcb/k7abd.py
+++ b/src/dzcb/k7abd.py
@@ -105,6 +105,10 @@ def Codeplug_from_zone_dicts(zone_dicts):
     all_channels = {}
     for zname, zchannels in zone_dicts.items():
         updated_channels = []
+        zscanlist = ScanList(
+            name=zname,
+            channels=updated_channels,
+        )
         for ch in zchannels:
             if isinstance(ch, DigitalChannel):
                 if ch.static_talkgroups:
@@ -112,7 +116,7 @@ def Codeplug_from_zone_dicts(zone_dicts):
                 if ch.talkgroup:
                     contacts.add(ch.talkgroup)
             if ch.scanlist is None:
-                ch = attr.evolve(ch, scanlist=zname)
+                ch = attr.evolve(ch, scanlist=zscanlist)
             # if the existing channel with this short name doesn't hash to
             # the current channel, then append a number until it does.
             # This will ensure all same short named channels get the same
@@ -121,11 +125,9 @@ def Codeplug_from_zone_dicts(zone_dicts):
                 ch = attr.evolve(ch, dedup_key=ch._dedup_key + 1)
             all_channels[ch.short_name] = ch
             updated_channels.append(ch)
-        zscanlist = ScanList(
-            name=zname,
-            channels=updated_channels,
+        scanlists.append(
+            attr.evolve(zscanlist, channels=updated_channels)
         )
-        scanlists.append(zscanlist)
         zones.append(
             Zone(
                 name=zname,

--- a/src/dzcb/model.py
+++ b/src/dzcb/model.py
@@ -155,7 +155,7 @@ class Channel:
     rx_only = attr.ib(
         default=False, validator=attr.validators.instance_of(bool), converter=bool
     )
-    scanlist = attr.ib(eq=False, default=None)
+    scanlist = attr.ib(eq=False, default=None, validator=attr.validators.optional(attr.validators.instance_of(uuid.UUID)))
     code = attr.ib(
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(str)),
@@ -223,7 +223,7 @@ class DigitalChannel(Channel):
     bandwidth = 12.5
     squelch = 0
     color_code = attr.ib(default=1)
-    grouplist = attr.ib(default=None)
+    grouplist = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(uuid.UUID)), converter=lambda gl: gl._id if isinstance(gl, GroupList) else gl)
     talkgroup = attr.ib(
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(Talkgroup)),
@@ -231,7 +231,7 @@ class DigitalChannel(Channel):
     # a list of other static talkgroups, which form the basis of an RX/scan list
     # eq is False here because the static talkgroups can change without necessarily
     # changing the identity of the channel itself
-    static_talkgroups = attr.ib(eq=False, factory=list)
+    static_talkgroups = attr.ib(eq=False, factory=list, validator=attr.validators.deep_iterable(member_validator=attr.validators.instance_of(Talkgroup)))
 
     def from_talkgroups(self, talkgroups):
         """
@@ -277,7 +277,10 @@ class ScanList:
     channels = attr.ib(
         eq=False,
         factory=tuple,
-        validator=attr.validators.deep_iterable(attr.validators.instance_of(Channel)),
+        validator=attr.validators.deep_iterable(
+            member_validator=attr.validators.instance_of(Channel),
+            iterable_validator=attr.validators.instance_of(tuple),
+        ),
         converter=tuple,
     )
     # stable id can track object across name and contents changes

--- a/src/dzcb/model.py
+++ b/src/dzcb/model.py
@@ -558,6 +558,7 @@ class Codeplug:
     grouplists = attr.ib(factory=tuple, converter=tuple, repr=_seq_items_repr)
     scanlists = attr.ib(factory=tuple, converter=tuple, repr=_seq_items_repr)
     zones = attr.ib(factory=tuple, converter=tuple, repr=_seq_items_repr)
+    _lookup_table = attr.ib(default=None, init=False, eq=False, repr=False)
 
     def _generate_lookup_table(self):
         """
@@ -578,9 +579,9 @@ class Codeplug:
         """
         Lookup a codeplug object by ID
         """
-        if not hasattr(self, "__lookup_table"):
-            self.__lookup_table = self._generate_lookup_table()
-        return self.__lookup_table[object_id]
+        if self._lookup_table is None:
+            self._lookup_table = self._generate_lookup_table()
+        return self._lookup_table[object_id]
 
     def filter(
         self,

--- a/src/dzcb/model.py
+++ b/src/dzcb/model.py
@@ -164,6 +164,10 @@ class Channel:
     # even when the short name would overlap
     _dedup_key = attr.ib(default=0, repr=False)
 
+    def scanlist_name(self, codeplug):
+        if self.scanlist:
+            return codeplug.lookup(self.scanlist).name
+
     @property
     def short_name(self):
         """Generate a short name for this channel"""
@@ -247,6 +251,10 @@ class DigitalChannel(Channel):
             )
             for tg in talkgroups
         ]
+
+    def grouplist_name(self, codeplug):
+        if self.grouplist:
+            return codeplug.lookup(self.grouplist).name
 
     @property
     def zone_name(self):

--- a/src/dzcb/model.py
+++ b/src/dzcb/model.py
@@ -291,9 +291,6 @@ class ScanList:
         sl_channels = []
         channels_by_name = {ch.name: ch for ch in channels}
         for cn in channel_names:
-            # TODO: require method to be called with a set of available channels
-            #       because the global list may contain channels that have already
-            #       been pruned in the given codeplug
             channel = channels_by_name.get(cn)
             if channel is None:
                 logger.debug(

--- a/src/dzcb/model.py
+++ b/src/dzcb/model.py
@@ -108,7 +108,15 @@ class GroupList:
     """
 
     name = attr.ib(eq=False, validator=attr.validators.instance_of(str))
-    contacts = attr.ib(factory=tuple, eq=False, validator=attr.validators.deep_iterable(member_validator=attr.validators.instance_of(Contact), iterable_validator=attr.validators.instance_of(tuple)), converter=tuple)
+    contacts = attr.ib(
+        factory=tuple,
+        eq=False,
+        validator=attr.validators.deep_iterable(
+            member_validator=attr.validators.instance_of(Contact),
+            iterable_validator=attr.validators.instance_of(tuple),
+        ),
+        converter=tuple,
+    )
     # stable id can track object across name and contents changes
     _id = attr.ib(factory=uuid.uuid4, repr=False)
 
@@ -155,7 +163,11 @@ class Channel:
     rx_only = attr.ib(
         default=False, validator=attr.validators.instance_of(bool), converter=bool
     )
-    scanlist = attr.ib(eq=False, default=None, validator=attr.validators.optional(attr.validators.instance_of(uuid.UUID)))
+    scanlist = attr.ib(
+        eq=False,
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(uuid.UUID)),
+    )
     code = attr.ib(
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(str)),
@@ -223,7 +235,11 @@ class DigitalChannel(Channel):
     bandwidth = 12.5
     squelch = 0
     color_code = attr.ib(default=1)
-    grouplist = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(uuid.UUID)), converter=lambda gl: gl._id if isinstance(gl, GroupList) else gl)
+    grouplist = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(uuid.UUID)),
+        converter=lambda gl: gl._id if isinstance(gl, GroupList) else gl,
+    )
     talkgroup = attr.ib(
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(Talkgroup)),
@@ -231,7 +247,13 @@ class DigitalChannel(Channel):
     # a list of other static talkgroups, which form the basis of an RX/scan list
     # eq is False here because the static talkgroups can change without necessarily
     # changing the identity of the channel itself
-    static_talkgroups = attr.ib(eq=False, factory=list, validator=attr.validators.deep_iterable(member_validator=attr.validators.instance_of(Talkgroup)))
+    static_talkgroups = attr.ib(
+        eq=False,
+        factory=list,
+        validator=attr.validators.deep_iterable(
+            member_validator=attr.validators.instance_of(Talkgroup)
+        ),
+    )
 
     def from_talkgroups(self, talkgroups):
         """
@@ -472,7 +494,11 @@ def uniquify_contacts(contacts, key=None):
     # check for duplicate DMR numbers, drop and warn
     contacts_by_id = {}
     for ct in ctd.values():
-        ct_key = (ct.dmrid, ct.kind, ct.timeslot) if isinstance(ct, Talkgroup) else (ct.dmrid, ct.kind)
+        ct_key = (
+            (ct.dmrid, ct.kind, ct.timeslot)
+            if isinstance(ct, Talkgroup)
+            else (ct.dmrid, ct.kind)
+        )
         stored_ct = contacts_by_id.setdefault(ct_key, ct)
         if stored_ct.name != ct.name:
             warnings.warn(
@@ -644,7 +670,9 @@ class Codeplug:
                     )
                 # update talkgroup reference to get the latest name
                 elif ch.talkgroup:
-                    updated_talkgroup = cp["contacts"][cp["contacts"].index(ch.talkgroup)]
+                    updated_talkgroup = cp["contacts"][
+                        cp["contacts"].index(ch.talkgroup)
+                    ]
                     if ch.talkgroup.name != updated_talkgroup.name:
                         return attr.evolve(
                             ch,
@@ -686,7 +714,9 @@ class Codeplug:
         # Reorder static talkgroups and remove channels with missing talkgroups
         contact_set = set(tg for tg in cp["contacts"])
         cp["channels"] = [
-            order_static_talkgroups(ch) for ch in cp["channels"] if talkgroup_exists(ch, contact_set)
+            order_static_talkgroups(ch)
+            for ch in cp["channels"]
+            if talkgroup_exists(ch, contact_set)
         ]
 
         # Prune orphan channels and contacts from containers

--- a/src/dzcb/model.py
+++ b/src/dzcb/model.py
@@ -167,6 +167,7 @@ class Channel:
         eq=False,
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(uuid.UUID)),
+        converter=lambda sl: sl._id if isinstance(sl, ScanList) else sl,
     )
     code = attr.ib(
         default=None,

--- a/src/dzcb/model.py
+++ b/src/dzcb/model.py
@@ -685,9 +685,16 @@ class Codeplug:
             return ch
 
         def talkgroup_exists(ch, contact_set):
-            if isinstance(ch, AnalogChannel) or ch.talkgroup is None:
+            if isinstance(ch, AnalogChannel):
                 return True
-            return ch.talkgroup in contact_set
+            if ch.static_talkgroups:
+                # missing talkgroups will be pruned by `order_static_talkgroups`
+                return any(tg in contact_set for tg in ch.static_talkgroups)
+            elif ch.talkgroup is not None:
+                return ch.talkgroup in contact_set
+            else:
+                # No talkgroup or static_talkgroups, prune channel
+                return False
 
         if exclude:
             _filter_inplace(exclude, _exclude_filter)

--- a/src/dzcb/model.py
+++ b/src/dzcb/model.py
@@ -256,9 +256,11 @@ class DigitalChannel(Channel):
         ),
     )
 
-    def from_talkgroups(self, talkgroups):
+    def from_talkgroups(self, talkgroups, **kwargs):
         """
-        Return a new channel per talkgroup based on this channel's settings
+        Return a new channel per talkgroup based on this channel's settings.
+
+        Additional kwargs will be applied to the new channel.
         """
 
         return [
@@ -269,8 +271,8 @@ class DigitalChannel(Channel):
                     (self.code if self.code else self.name)[:3],
                 ),
                 talkgroup=tg,
-                scanlist=self.scanlist,
                 static_talkgroups=[],
+                **kwargs,
             )
             for tg in talkgroups
         ]
@@ -771,14 +773,15 @@ class Codeplug:
             if not isinstance(ch, DigitalChannel) or not ch.static_talkgroups:
                 channels.append(ch)
                 continue
-            zone_channels = ch.from_talkgroups(
-                ch.static_talkgroups,
-            )
             zscanlist = ScanList(
                 name=ch.short_name,
-                channels=zone_channels,
+                channels=[],
             )
-            exp_scanlists.append(zscanlist)
+            zone_channels = ch.from_talkgroups(
+                ch.static_talkgroups,
+                scanlist=zscanlist,
+            )
+            exp_scanlists.append(attr.evolve(zscanlist, channels=zone_channels))
             zones.append(
                 Zone(
                     name=ch.short_name,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -281,3 +281,12 @@ def test_Grouplist_replacements(complex_codeplug):
     )
     assert gl_replacements.channels[0].grouplist_name(complex_codeplug) == old
     assert gl_replacements.channels[0].grouplist_name(gl_replacements) == new
+
+
+def test_lookup_table_regen(complex_codeplug):
+    with pytest.raises(KeyError):
+        complex_codeplug.lookup("foo")
+    assert complex_codeplug._lookup_table is not None
+    new_cp = complex_codeplug.filter()
+    assert new_cp._lookup_table is None
+    assert complex_codeplug._lookup_table is not None

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -68,27 +68,45 @@ def complex_codeplug():
         dzcb.model.Talkgroup("PC2", 0xE02, dzcb.model.ContactType.PRIVATE, timeslot=2),
         dzcb.model.Talkgroup("PC3", 0xE03, dzcb.model.ContactType.PRIVATE, timeslot=1),
     )
-    channels = (
-        dzcb.model.AnalogChannel("A1", "146.520", "6.0"),
-        dzcb.model.AnalogChannel("A2", "146.530", "6.0"),
-        dzcb.model.AnalogChannel("A3", "146.540", "6.0"),
-        dzcb.model.DigitalChannel("D1", "443.4375", "9", talkgroup=contacts[0]),
-        dzcb.model.DigitalChannel("D2", "443.4375", "9", talkgroup=contacts[1]),
-        dzcb.model.DigitalChannel("D3", "443.4375", "9", talkgroup=contacts[2]),
-        dzcb.model.DigitalChannel(
-            "DR1", "443.4375", "9", static_talkgroups=contacts[:]
-        ),
-        dzcb.model.DigitalChannel(
-            "DR2", "444.4375", "9", static_talkgroups=[contacts[0], contacts[1]]
-        ),
-        dzcb.model.DigitalChannel(
-            "DR3", "445.4375", "9", static_talkgroups=[contacts[3], contacts[4]]
-        ),
-    )
     grouplists = (
         dzcb.model.GroupList("GL_ALL", contacts[:]),
         dzcb.model.GroupList("GL_GRP", contacts[:3]),
         dzcb.model.GroupList("GL_PRV", contacts[3:]),
+    )
+    channels = (
+        dzcb.model.AnalogChannel("A1", "146.520", "6.0"),
+        dzcb.model.AnalogChannel("A2", "146.530", "6.0"),
+        dzcb.model.AnalogChannel("A3", "146.540", "6.0"),
+        dzcb.model.DigitalChannel(
+            "D1", "443.4375", "9", talkgroup=contacts[0], grouplist=grouplists[0]
+        ),
+        dzcb.model.DigitalChannel(
+            "D2", "443.4375", "9", talkgroup=contacts[1], grouplist=grouplists[1]
+        ),
+        dzcb.model.DigitalChannel(
+            "D3", "443.4375", "9", talkgroup=contacts[2], grouplist=grouplists[1]
+        ),
+        dzcb.model.DigitalChannel(
+            "DR1",
+            "443.4375",
+            "9",
+            static_talkgroups=contacts[:],
+            grouplist=grouplists[1],
+        ),
+        dzcb.model.DigitalChannel(
+            "DR2",
+            "444.4375",
+            "9",
+            static_talkgroups=[contacts[0], contacts[1]],
+            grouplist=grouplists[1],
+        ),
+        dzcb.model.DigitalChannel(
+            "DR3",
+            "445.4375",
+            "9",
+            static_talkgroups=[contacts[3], contacts[4]],
+            grouplist=grouplists[2],
+        ),
     )
     scanlists = (
         dzcb.model.ScanList("SL_ALL", channels[:]),
@@ -252,3 +270,14 @@ def test_Channel_exclude_replacements(complex_codeplug):
         "D2",
         "DigitalRepeater1",
     ]
+
+
+def test_Grouplist_replacements(complex_codeplug):
+    old = "GL_ALL"
+    new = "gl_all"
+    gl_replacements = complex_codeplug.filter(
+        include=dzcb.model.Ordering(channels=["D1"]),
+        replacements=dzcb.model.Replacements(grouplists=((old, new),)),
+    )
+    assert gl_replacements.channels[0].grouplist_name(complex_codeplug) == old
+    assert gl_replacements.channels[0].grouplist_name(gl_replacements) == new

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -283,6 +283,25 @@ def test_Grouplist_replacements(complex_codeplug):
     assert gl_replacements.channels[0].grouplist_name(gl_replacements) == new
 
 
+def test_Contact_replacements(complex_codeplug):
+    ct_replacements = complex_codeplug.filter(
+        replacements=dzcb.model.Replacements(contacts=(("CT1", "ContactOne"),)),
+        include=dzcb.model.Ordering(contacts=["ContactOne", "CT2"]),
+        exclude=dzcb.model.Ordering(channels=["A"]),
+    )
+    assert [ch.name for ch in ct_replacements.channels] == ["D1", "D2", "DR1", "DR2"]
+    assert ct_replacements.channels[0].talkgroup.name == "ContactOne"
+    assert ct_replacements.channels[1].talkgroup.name == "CT2"
+    assert [tg.name for tg in ct_replacements.channels[2].static_talkgroups] == [
+        "ContactOne",
+        "CT2",
+    ]
+    assert [tg.name for tg in ct_replacements.channels[3].static_talkgroups] == [
+        "ContactOne",
+        "CT2",
+    ]
+
+
 def test_lookup_table_regen(complex_codeplug):
     with pytest.raises(KeyError):
         complex_codeplug.lookup("foo")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -37,11 +37,16 @@ def test_ordering_zones_contacts():
 
 @pytest.fixture
 def simple_codeplug():
+    contacts = (
+        dzcb.model.Talkgroup(
+            "Foo", 0xF00, dzcb.model.ContactType.GROUP, dzcb.model.Timeslot.ONE
+        ),
+    )
     return dzcb.model.Codeplug(
-        contacts=(dzcb.model.Contact("Foo", 0xF00, dzcb.model.ContactType.GROUP),),
+        contacts=contacts,
         channels=(
             dzcb.model.AnalogChannel("Bar", "146.520", "6.0"),
-            dzcb.model.DigitalChannel("Baz", "443.4375", "9"),
+            dzcb.model.DigitalChannel("Baz", "443.4375", "9", talkgroup=contacts[0]),
         ),
         grouplists=(dzcb.model.GroupList("Quuc", []),),
         scanlists=(dzcb.model.ScanList("Flar", []),),

--- a/tools/profile_top_callers.py
+++ b/tools/profile_top_callers.py
@@ -1,0 +1,5 @@
+import pstats
+import sys
+
+p = pstats.Stats(sys.argv[1])
+p.sort_stats(pstats.SortKey.CUMULATIVE).print_stats(15)


### PR DESCRIPTION
fixes #58

Ensure that the most recent version of a ScanList or GroupList can be picked when writing output files.