### PR TITLE
dmrconfig: Contact by name update

### DIFF
--- a/src/dzcb/output/dmrconfig.py
+++ b/src/dzcb/output/dmrconfig.py
@@ -329,7 +329,6 @@ def uniquify_contacts_by_name(codeplug):
 class Table:
     codeplug = attr.ib(
         validator=attr.validators.instance_of(Codeplug),
-        converter=uniquify_contacts_by_name,
     )
     radio = attr.ib(default=Radio.D868UV, validator=attr.validators.instance_of(Radio))
     index = attr.ib(validator=attr.validators.instance_of(CodeplugIndexLookup))

--- a/src/dzcb/output/dmrconfig.py
+++ b/src/dzcb/output/dmrconfig.py
@@ -30,7 +30,6 @@ from dzcb.model import (
     Power,
     AnalogChannel,
     DigitalChannel,
-    uniquify_contacts,
 )
 
 
@@ -319,12 +318,6 @@ class CodeplugIndexLookup:
     @channel.default
     def _channel(self):
         return items_by_index(self.codeplug.channels, offset=self.offset)
-
-
-def uniquify_contacts_by_name(codeplug):
-    return attr.evolve(
-        codeplug, contacts=uniquify_contacts(codeplug.contacts, key=lambda ct: ct.name)
-    )
 
 
 @attr.s

--- a/src/dzcb/output/dmrconfig.py
+++ b/src/dzcb/output/dmrconfig.py
@@ -719,6 +719,12 @@ class ContactsTable(Table):
     def docs(self):
         return super().docs(contact_limit=f"1-{self.radio.value.ncontacts}")
 
+    def __iter__(self):
+        return self.iter_objects(
+            uniquify_contacts(self.codeplug.contacts, key=lambda ct: ct.name),
+            object_limit=self.radio.value.limit(self.object_name),
+        )
+
 
 class GrouplistTable(Table):
     """

--- a/src/dzcb/output/dmrconfig.py
+++ b/src/dzcb/output/dmrconfig.py
@@ -212,10 +212,16 @@ def items_by_index(
 ) -> Dict[Any, int]:
     """
     Build a mapping of items to indexes in the all_items sequence.
+
+    Sort of removing duplicates, i guess
     """
-    return {
-        key(item) if key else item: ix + offset for ix, item in enumerate(all_items)
-    }
+    ibb = {}
+    ix = 0
+    for item in all_items:
+        k = key(item) if key else item
+        ibb.setdefault(k, ix + offset)
+        ix += 1
+    return ibb
 
 
 def items_to_range_tuples(

--- a/src/dzcb/output/dmrconfig.py
+++ b/src/dzcb/output/dmrconfig.py
@@ -938,6 +938,8 @@ def evolve_from_factory(table_type):
     """
     Responsible for applying template values to the passed in Table
     when creating subtables in Dmrconfig_Codeplug
+
+    TODO: need coverage for this function
     """
 
     def _evolve_from(self):

--- a/src/dzcb/output/dmrconfig.py
+++ b/src/dzcb/output/dmrconfig.py
@@ -373,22 +373,25 @@ class Table:
         tdict.update(kwargs)
         return cls(**tdict)
 
-    def __iter__(self):
-        if not self.object_name:
-            raise NotImplementedError("No object_name specified for {!r}".format(self))
-        object_list = getattr(self.codeplug, self.object_name)
-        object_limit = self.radio.value.limit(self.object_name)
+    def iter_objects(self, object_list, object_limit=None):
         for ix, item in enumerate(object_list):
-            if ix + 1 > object_limit:
+            if object_limit is not None and ix + 1 > object_limit:
                 logger.debug(
                     "{0} table is full, ignoring {1} {0}".format(
-                        self.object_name, len(object_list) - ix
+                        type(item).__name__, len(object_list) - ix
                     )
                 )
                 break
             row = self.format_row(ix + 1, item)
             if row:
                 yield row
+
+    def __iter__(self):
+        if not self.object_name:
+            raise NotImplementedError("No object_name specified for {!r}".format(self))
+        object_list = getattr(self.codeplug, self.object_name)
+        object_limit = self.radio.value.limit(self.object_name)
+        return self.iter_objects(object_list, object_limit=object_limit)
 
 
 class ChannelTable(Table):

--- a/src/dzcb/output/dmrconfig.py
+++ b/src/dzcb/output/dmrconfig.py
@@ -785,7 +785,7 @@ class DmrConfigTemplate:
     )
     ranges = attr.ib(
         default=None,
-        validator=attr.validators.optional(attr.validators.deep_iterable(tuple, tuple)),
+        validator=attr.validators.optional(attr.validators.deep_iterable(attr.validators.instance_of(tuple), attr.validators.instance_of(tuple))),
     )
     include_docs = attr.ib(
         default=None,

--- a/src/dzcb/output/dmrconfig.py
+++ b/src/dzcb/output/dmrconfig.py
@@ -300,7 +300,9 @@ class CodeplugIndexLookup:
     @contact.default
     def _contact(self):
         # contact index keys on contact name
-        return items_by_index(self.codeplug.contacts, key=lambda ct: ct.name, offset=self.offset)
+        return items_by_index(
+            self.codeplug.contacts, key=lambda ct: ct.name, offset=self.offset
+        )
 
     @grouplist_id.default
     def _grouplist_id(self):
@@ -793,7 +795,11 @@ class DmrConfigTemplate:
     )
     ranges = attr.ib(
         default=None,
-        validator=attr.validators.optional(attr.validators.deep_iterable(attr.validators.instance_of(tuple), attr.validators.instance_of(tuple))),
+        validator=attr.validators.optional(
+            attr.validators.deep_iterable(
+                attr.validators.instance_of(tuple), attr.validators.instance_of(tuple)
+            )
+        ),
     )
     include_docs = attr.ib(
         default=None,
@@ -996,7 +1002,11 @@ class Dmrconfig_Codeplug:
             raise RuntimeError("no template is defined")
         return "\n".join(
             tuple(self.template.header)
-            + (("", self.template.version_comment_line) if self.template.include_version is not False else tuple())
+            + (
+                ("", self.template.version_comment_line)
+                if self.template.include_version is not False
+                else tuple()
+            )
             + self.render()
             + tuple(self.template.footer)
         )

--- a/src/dzcb/output/dmrconfig.py
+++ b/src/dzcb/output/dmrconfig.py
@@ -874,6 +874,9 @@ class DmrConfigTemplate:
 
         raise TemplateError if template doesn't contain a valid "Radio: X" line
         """
+        if isinstance(template, cls):
+            return template  # already a template, done
+
         consuming_table = dict(
             name=None,
             lines=[],

--- a/tests/test_dmrconfig.py
+++ b/tests/test_dmrconfig.py
@@ -66,6 +66,6 @@ def test_dmrconfig_contact_integrity(same_contact_both_timeslots_codeplug):
         table=dzcb.output.dmrconfig.Table(codeplug=exp_cp),
     )
 
-    dmrconfig_conf = "\n".join(dmrconfig_cp.render())
+    digital_channels = "\n".join(dmrconfig_cp.digital.render())
     for ch_name in exp_channel_names:
-        assert ch_name.replace(" ", "_") in dmrconfig_conf
+        assert ch_name.replace(" ", "_") in digital_channels

--- a/tests/test_dmrconfig.py
+++ b/tests/test_dmrconfig.py
@@ -54,7 +54,20 @@ def same_contact_both_timeslots_codeplug():
     )
 
 
-def test_dmrconfig_contact_integrity(same_contact_both_timeslots_codeplug):
+@pytest.fixture(
+    params=(
+        pytest.param(True, id="filter"),
+        pytest.param(False, id="raw"),
+    )
+)
+def template_filter(request):
+    if request.param:
+        return dzcb.output.dmrconfig.DmrConfigTemplate(
+            ranges=((0.0, 6000.0),),
+        )
+
+
+def test_dmrconfig_contact_integrity(same_contact_both_timeslots_codeplug, template_filter):
     cp = same_contact_both_timeslots_codeplug
     assert len(cp.channels) == 1
 
@@ -63,7 +76,8 @@ def test_dmrconfig_contact_integrity(same_contact_both_timeslots_codeplug):
     assert tuple(ch.name for ch in exp_cp.channels) == exp_channel_names
 
     dmrconfig_cp = dzcb.output.dmrconfig.Dmrconfig_Codeplug(
-        table=dzcb.output.dmrconfig.Table(codeplug=exp_cp),
+        table=dzcb.output.dmrconfig.Table(codeplug=exp_cp, include_docs=False),
+        template=template_filter,
     )
 
     digital_channels = "\n".join(dmrconfig_cp.digital.render())


### PR DESCRIPTION
Well, fixing #65 sort of went down a rabbit hole of various improvements to attempt to find the problem and fix it with a reasonable amount of churn. Regression tests pass, and spot checks of more complex codeplug are clear.

It turned out that `uniquify_contacts` with a name-only key is not compatible with subsequent filtering of the codeplug due to the post-filtering stage that removes channels with talkgroups that don't exist. Channels always carry the timeslot information in the talkgroup and thus the timeslot is necessarily a part of the Talkgroup hash.

So instead of a direct fix, we kind of step around the problem. Defer the uniquifying of the contacts to _after_ filtering, and without affecting the original codeplug. Filter the contacts in `CodeplugIndex`. Yep, it's definitely doesn't smell awesome.

Looking forward to a new `MutableCodeplug` API, wrapping the codeplug-as-a-dict construct, while providing filtering and consistency methods.