### PR TITLE
Zone channel ordering

### DIFF
--- a/src/dzcb/recipe.py
+++ b/src/dzcb/recipe.py
@@ -532,14 +532,11 @@ class CodeplugRecipe:
         )
 
         dm_outdir = append_dir_and_create(self.output_dir, "dmrconfig")
-        table = dzcb.output.dmrconfig.Table(
-            codeplug=self._codeplug_expanded,
-        )
         for dt in dmrconfig_templates:
             outfile = dm_outdir / dt.name
             outfile.write_text(
-                dzcb.output.dmrconfig.Dmrconfig_Codeplug(
-                    table,
+                dzcb.output.dmrconfig.Dmrconfig_Codeplug.from_codeplug(
+                    self._codeplug_expanded,
                     template=cache_user_or_default_text(
                         "dmrconfig template",
                         dt,

--- a/tests/default-codeplug-expect-output/dmrconfig/md380-int.conf
+++ b/tests/default-codeplug-expect-output/dmrconfig/md380-int.conf
@@ -41,103 +41,103 @@ Analog Name             Receive  Transmit Power  Scan TOT RO Admit Squelch RxTon
   17   Yacolt_443.12500  443.125  448.125 High      4  90 -  Free  Normal  94.8   94.8   25
   18   Yacolt_440.32500  440.325  445.325 High      4  90 -  Free  Normal  100.0  100.0  25
   19   Hazel_Dell_443.8    443.8    448.8 High      4  90 -  Free  Normal  -      100.0  25
-  20   Hockinson_444.72  444.725  449.725 High      4  90 -  Free  Normal  -      107.2  25
-  21   Vancouver_440.15   440.15   445.15 High      4  90 -  Free  Normal  -      -      25
-  22   Portland_443.225  443.225  448.225 High      4  90 -  Free  Normal  107.2  107.2  25
-  23   Portland_440.825  440.825  445.825 High      4  90 -  Free  Normal  110.9  110.9  25
-  24   Portland_440.512 440.5125 445.5125 High      4  90 -  Free  Normal  -      -      25
-  25   Portland_442.700    442.7    447.7 High      4  90 -  Free  Normal  -      100.0  25
-  26   Portland_440.350   440.35   445.35 High      4  90 -  Free  Normal  127.3  127.3  25
-  27   Portland_443.050   443.05   448.05 High      4  90 -  Free  Normal  -      -      25
-  28   Portland_443.275  443.275  448.275 High      4  90 -  Free  Normal  167.9  167.9  25
-  29   Portland_442.650   442.65   447.65 High      4  90 -  Free  Normal  100.0  100.0  25
-  30   Portland_440.400    440.4    445.4 High      4  90 -  Free  Normal  123.0  123.0  25
-  31   Portland_442.225  442.225  447.225 High      4  90 -  Free  Normal  103.5  103.5  25
-  32   Portland_443.300    443.3    448.3 High      4  90 -  Free  Normal  100.0  100.0  25
-  33   Portland_444.837 444.8375 449.8375 High      4  90 -  Free  Normal  -      -      25
-  34   Portland_441.350   441.35   446.35 High      4  90 -  Free  Normal  100.0  100.0  25
-  35   Portland_443.625  443.625  448.625 High      4  90 -  Free  Normal  77.0   77.0   25
-  36   Portland_440.200    440.2    445.2 High      4  90 -  Free  Normal  -      100.0  25
-  37   Portland_440.500    440.5    445.5 High      4  90 -  Free  Normal  D125N  D125N  25
-  38   Portland_440.450   440.45   445.45 High      4  90 -  Free  Normal  103.5  103.5  25
-  39   Portland_442.250   442.25   447.25 High      4  90 -  Free  Normal  100.0  100.0  25
-  40   Beaverton_444.85   444.85   449.85 High      4  90 -  Free  Normal  -      123.0  25
-  41   Portland_443.550   443.55   448.55 High      4  90 -  Free  Normal  -      100.0  25
-  42   Cedar_Mill_444.8    444.8    449.8 High      4  90 -  Free  Normal  -      107.2  25
-  43   Beaverton_444.75   444.75   449.75 High      4  90 -  Free  Normal  -      123.0  25
-  44   Lake_Oswego_444.    444.3    449.3 High      4  90 -  Free  Normal  82.5   82.5   25
-  45   Clackamas_441.32  441.325  446.325 High      4  90 -  Free  Normal  -      -      25
-  46   Clackamas_440.30    440.3    445.3 High      4  90 -  Free  Normal  -      167.9  25
-  47   Clackamas_443.47  443.475  448.475 High      4  90 -  Free  Normal  167.9  167.9  25
-  48   Clackamas_443.15   443.15   448.15 High      4  90 -  Free  Normal  107.2  107.2  25
-  49   Vancouver_443.82  443.825  448.825 High      4  90 -  Free  Normal  94.8   94.8   25
-  50   Aloha_443.35000    443.35   448.35 High      4  90 -  Free  Normal  -      156.7  25
-  51   Portland_443.200    443.2    448.2 High      4  90 -  Free  Normal  -      173.8  25
-  52   Tigard_440.17500  440.175  445.175 High      4  90 -  Free  Normal  110.9  110.9  25
-  53   Vancouver_442.10    442.1    447.1 High      4  90 -  Free  Normal  127.3  127.3  25
-  54   Aloha_442.52500   442.525  447.525 High      4  90 -  Free  Normal  107.2  107.2  25
-  55   Hillsboro_440.55   440.55   445.55 High      4  90 -  Free  Normal  -      -      25
-  56   Tualatin_444.525  444.525  449.525 High      4  90 -  Free  Normal  -      136.5  25
-  57   West_Linn_441.65   441.65   446.65 High      4  90 -  Free  Normal  -      107.2  25
-  58   Gresham_446.2750  446.275  446.275 High      4  90 -  Free  Normal  -      167.9  25
-  59   OR_City_442.0750  442.075  447.075 High      4  90 -  Free  Normal  103.5  103.5  25
-  60   Camas_444.52500   444.525  449.525 High      4  90 -  Free  Normal  103.5  103.5  25
-  61   Gresham_443.0750  443.075  448.075 High      4  90 -  Free  Normal  -      -      25
-  62   Hillsboro_444.97  444.975  449.975 High      4  90 -  Free  Normal  107.2  107.2  25
-  63   Sherwood_442.275  442.275  447.275 High      4  90 -  Free  Normal  -      107.2  25
-  64   Sherwood_444.312 444.3125 449.3125 High      4  90 -  Free  Normal  -      -      25
-  65   Sherwood_443.425  443.425  448.425 High      4  90 -  Free  Normal  -      107.2  25
-  66   Sherwood_442.575  442.575  447.575 High      4  90 -  Free  Normal  -      123.0  25
-  67   Boring_441.95000   441.95   446.95 High      4  90 -  Free  Normal  -      100.0  25
-  68   Canby_442.90000     442.9    447.9 High      4  90 -  Free  Normal  -      123.0  25
-  69   Canby_444.45000    444.45   449.45 High      4  90 -  Free  Normal  -      131.8  25
-  70   Newberg_442.6750  442.675  447.675 High      4  90 -  Free  Normal  100.0  100.0  25
-  71   Vancouver_442.37  442.375  447.375 High      4  90 -  Free  Normal  100.0  123.0  25
-  72   Camas_443.92500   443.925  448.925 High      4  90 -  Free  Normal  94.8   94.8   25
-  73   Newberg_443.7500   443.75   448.75 High      4  90 -  Free  Normal  -      100.0  25
-  74   Corbett_443.1000    443.1    448.1 High      4  90 -  Free  Normal  -      -      25
-  75   Laurelwood_443.6   443.65   448.65 High      4  90 -  Free  Normal  -      100.0  25
-  76   Newberg_444.4875 444.4875 449.4875 High      4  90 -  Free  Normal  -      -      25
-  77   Sandy_442.42500   442.425  447.425 High      4  90 -  Free  Normal  -      100.0  25
-  78   Newberg_442.5500   442.55   447.55 High      4  90 -  Free  Normal  -      114.8  25
-  79   Sandy_442.87500   442.875  447.875 High      4  90 -  Free  Normal  107.2  107.2  25
-  80   Vancouver_443.67  443.675  448.675 High      4  90 -  Free  Normal  -      107.2  25
-  81   Vancouver_443.90    443.9    448.9 High      4  90 -  Free  Normal  94.8   94.8   25
-  82   Vancouver_440.01 440.0125 445.0125 High      4  90 -  Free  Normal  -      -      25
-  83   Vancouver_442.96 442.9625 447.9625 High      4  90 -  Free  Normal  -      -      25
-  84   Beavercreek_444.    444.6    449.6 High      4  90 -  Free  Normal  -      100.0  25
-  85   Molalla_440.7000    440.7    445.7 High      4  90 -  Free  Normal  77.0   77.0   25
-  86   Colton_442.92500  442.925  447.925 High      4  90 -  Free  Normal  -      107.2  25
-  87   FM_446.000          446.0    446.0 High      5  90 -  Free  Normal  -      -      25
-  88   FM_446.025        446.025  446.025 High      5  90 -  Free  Normal  -      -      25
-  89   FM_445.8            445.8    445.8 High      5  90 -  Free  Normal  -      -      25
-  90   FM_445.825        445.825  445.825 High      5  90 -  Free  Normal  -      -      25
-  91   FM_445.85          445.85   445.85 High      5  90 -  Free  Normal  -      -      25
-  92   FM_445.875        445.875  445.875 High      5  90 -  Free  Normal  -      -      25
-  93   FM_445.9            445.9    445.9 High      5  90 -  Free  Normal  -      -      25
-  94   FM_445.975        445.975  445.975 High      5  90 -  Free  Normal  -      -      25
-  95   FRS_1            462.5625 462.5625 Low       8  90 -  Free  Normal  -      -      12.5
-  96   FRS_2            462.5875 462.5875 Low       8  90 -  Free  Normal  -      -      12.5
-  97   FRS_3            462.6125 462.6125 Low       8  90 -  Free  Normal  -      -      12.5
-  98   FRS_4            462.6375 462.6375 Low       8  90 -  Free  Normal  -      -      12.5
-  99   FRS_5            462.6675 462.6675 Low       8  90 -  Free  Normal  -      -      12.5
- 100   FRS_6            462.6875 462.6875 Low       8  90 -  Free  Normal  -      -      12.5
- 101   FRS_7            462.7125 462.7125 Low       8  90 -  Free  Normal  -      -      12.5
- 102   FRS_8_(IS)       467.5625 467.5625 Low       8  90 -  Free  Normal  -      -      12.5
- 103   FRS_9_(IS)       467.5875 467.5875 Low       8  90 -  Free  Normal  -      -      12.5
- 104   FRS_10_(IS)      467.6125 467.6125 Low       8  90 -  Free  Normal  -      -      12.5
- 105   FRS_11_(IS)      467.6375 467.6375 Low       8  90 -  Free  Normal  -      -      12.5
- 106   FRS_12_(IS)      467.6625 467.6625 Low       8  90 -  Free  Normal  -      -      12.5
- 107   FRS_13_(IS)      467.6875 467.6875 Low       8  90 -  Free  Normal  -      -      12.5
- 108   FRS_14_(IS)      467.7125 467.7125 Low       8  90 -  Free  Normal  -      -      12.5
- 109   GMRS_1_(15)        462.55   462.55 High      9  90 -  Free  Normal  -      -      20
- 110   GMRS_2_(16)       462.575  462.575 High      9  90 -  Free  Normal  -      -      20
- 111   GMRS_3_(17)         462.6    462.6 High      9  90 -  Free  Normal  -      -      20
- 112   GMRS_4_(18)       462.625  462.625 High      9  90 -  Free  Normal  -      -      20
- 113   GMRS_5_(19)        462.65   462.65 High      9  90 -  Free  Normal  -      -      20
- 114   GMRS_6_(20)       462.675  462.675 High      9  90 -  Free  Normal  -      -      20
- 115   GMRS_7_(21)         462.7    462.7 High      9  90 -  Free  Normal  -      -      20
- 116   GMRS_8_(22)       462.725  462.725 High      9  90 -  Free  Normal  -      -      20
+  20   FM_446.000          446.0    446.0 High      5  90 -  Free  Normal  -      -      25
+  21   FM_446.025        446.025  446.025 High      5  90 -  Free  Normal  -      -      25
+  22   FM_445.8            445.8    445.8 High      5  90 -  Free  Normal  -      -      25
+  23   FM_445.825        445.825  445.825 High      5  90 -  Free  Normal  -      -      25
+  24   FM_445.85          445.85   445.85 High      5  90 -  Free  Normal  -      -      25
+  25   FM_445.875        445.875  445.875 High      5  90 -  Free  Normal  -      -      25
+  26   FM_445.9            445.9    445.9 High      5  90 -  Free  Normal  -      -      25
+  27   FM_445.975        445.975  445.975 High      5  90 -  Free  Normal  -      -      25
+  36   Hockinson_444.72  444.725  449.725 High      4  90 -  Free  Normal  -      107.2  25
+  37   Vancouver_440.15   440.15   445.15 High      4  90 -  Free  Normal  -      -      25
+  38   Portland_443.225  443.225  448.225 High      4  90 -  Free  Normal  107.2  107.2  25
+  39   Portland_440.825  440.825  445.825 High      4  90 -  Free  Normal  110.9  110.9  25
+  40   Portland_440.512 440.5125 445.5125 High      4  90 -  Free  Normal  -      -      25
+  41   Portland_442.700    442.7    447.7 High      4  90 -  Free  Normal  -      100.0  25
+  42   Portland_440.350   440.35   445.35 High      4  90 -  Free  Normal  127.3  127.3  25
+  43   Portland_443.050   443.05   448.05 High      4  90 -  Free  Normal  -      -      25
+  44   Portland_443.275  443.275  448.275 High      4  90 -  Free  Normal  167.9  167.9  25
+  45   Portland_442.650   442.65   447.65 High      4  90 -  Free  Normal  100.0  100.0  25
+  46   Portland_440.400    440.4    445.4 High      4  90 -  Free  Normal  123.0  123.0  25
+  47   Portland_442.225  442.225  447.225 High      4  90 -  Free  Normal  103.5  103.5  25
+  48   Portland_443.300    443.3    448.3 High      4  90 -  Free  Normal  100.0  100.0  25
+  49   Portland_444.837 444.8375 449.8375 High      4  90 -  Free  Normal  -      -      25
+  50   Portland_441.350   441.35   446.35 High      4  90 -  Free  Normal  100.0  100.0  25
+  51   Portland_443.625  443.625  448.625 High      4  90 -  Free  Normal  77.0   77.0   25
+  52   Portland_440.200    440.2    445.2 High      4  90 -  Free  Normal  -      100.0  25
+  53   Portland_440.500    440.5    445.5 High      4  90 -  Free  Normal  D125N  D125N  25
+  54   Portland_440.450   440.45   445.45 High      4  90 -  Free  Normal  103.5  103.5  25
+  55   Portland_442.250   442.25   447.25 High      4  90 -  Free  Normal  100.0  100.0  25
+  56   Beaverton_444.85   444.85   449.85 High      4  90 -  Free  Normal  -      123.0  25
+  57   Portland_443.550   443.55   448.55 High      4  90 -  Free  Normal  -      100.0  25
+  58   Cedar_Mill_444.8    444.8    449.8 High      4  90 -  Free  Normal  -      107.2  25
+  59   Beaverton_444.75   444.75   449.75 High      4  90 -  Free  Normal  -      123.0  25
+  60   Lake_Oswego_444.    444.3    449.3 High      4  90 -  Free  Normal  82.5   82.5   25
+  61   Clackamas_441.32  441.325  446.325 High      4  90 -  Free  Normal  -      -      25
+  62   Clackamas_440.30    440.3    445.3 High      4  90 -  Free  Normal  -      167.9  25
+  63   Clackamas_443.47  443.475  448.475 High      4  90 -  Free  Normal  167.9  167.9  25
+  64   Clackamas_443.15   443.15   448.15 High      4  90 -  Free  Normal  107.2  107.2  25
+  65   Vancouver_443.82  443.825  448.825 High      4  90 -  Free  Normal  94.8   94.8   25
+  66   Aloha_443.35000    443.35   448.35 High      4  90 -  Free  Normal  -      156.7  25
+  67   Portland_443.200    443.2    448.2 High      4  90 -  Free  Normal  -      173.8  25
+  68   Tigard_440.17500  440.175  445.175 High      4  90 -  Free  Normal  110.9  110.9  25
+  69   Vancouver_442.10    442.1    447.1 High      4  90 -  Free  Normal  127.3  127.3  25
+  70   Aloha_442.52500   442.525  447.525 High      4  90 -  Free  Normal  107.2  107.2  25
+  71   Hillsboro_440.55   440.55   445.55 High      4  90 -  Free  Normal  -      -      25
+  72   Tualatin_444.525  444.525  449.525 High      4  90 -  Free  Normal  -      136.5  25
+  73   West_Linn_441.65   441.65   446.65 High      4  90 -  Free  Normal  -      107.2  25
+  74   Gresham_446.2750  446.275  446.275 High      4  90 -  Free  Normal  -      167.9  25
+  75   OR_City_442.0750  442.075  447.075 High      4  90 -  Free  Normal  103.5  103.5  25
+  76   Camas_444.52500   444.525  449.525 High      4  90 -  Free  Normal  103.5  103.5  25
+  77   Gresham_443.0750  443.075  448.075 High      4  90 -  Free  Normal  -      -      25
+  78   Hillsboro_444.97  444.975  449.975 High      4  90 -  Free  Normal  107.2  107.2  25
+  79   Sherwood_442.275  442.275  447.275 High      4  90 -  Free  Normal  -      107.2  25
+  80   Sherwood_444.312 444.3125 449.3125 High      4  90 -  Free  Normal  -      -      25
+  81   Sherwood_443.425  443.425  448.425 High      4  90 -  Free  Normal  -      107.2  25
+  82   Sherwood_442.575  442.575  447.575 High      4  90 -  Free  Normal  -      123.0  25
+  83   Boring_441.95000   441.95   446.95 High      4  90 -  Free  Normal  -      100.0  25
+  84   Canby_442.90000     442.9    447.9 High      4  90 -  Free  Normal  -      123.0  25
+  85   Canby_444.45000    444.45   449.45 High      4  90 -  Free  Normal  -      131.8  25
+  86   Newberg_442.6750  442.675  447.675 High      4  90 -  Free  Normal  100.0  100.0  25
+  87   Vancouver_442.37  442.375  447.375 High      4  90 -  Free  Normal  100.0  123.0  25
+  88   Camas_443.92500   443.925  448.925 High      4  90 -  Free  Normal  94.8   94.8   25
+  89   Newberg_443.7500   443.75   448.75 High      4  90 -  Free  Normal  -      100.0  25
+  90   Corbett_443.1000    443.1    448.1 High      4  90 -  Free  Normal  -      -      25
+  91   Laurelwood_443.6   443.65   448.65 High      4  90 -  Free  Normal  -      100.0  25
+  92   Newberg_444.4875 444.4875 449.4875 High      4  90 -  Free  Normal  -      -      25
+  93   Sandy_442.42500   442.425  447.425 High      4  90 -  Free  Normal  -      100.0  25
+  94   Newberg_442.5500   442.55   447.55 High      4  90 -  Free  Normal  -      114.8  25
+  95   Sandy_442.87500   442.875  447.875 High      4  90 -  Free  Normal  107.2  107.2  25
+  96   Vancouver_443.67  443.675  448.675 High      4  90 -  Free  Normal  -      107.2  25
+  97   Vancouver_443.90    443.9    448.9 High      4  90 -  Free  Normal  94.8   94.8   25
+  98   Vancouver_440.01 440.0125 445.0125 High      4  90 -  Free  Normal  -      -      25
+  99   Vancouver_442.96 442.9625 447.9625 High      4  90 -  Free  Normal  -      -      25
+ 100   Beavercreek_444.    444.6    449.6 High      4  90 -  Free  Normal  -      100.0  25
+ 101   Molalla_440.7000    440.7    445.7 High      4  90 -  Free  Normal  77.0   77.0   25
+ 102   Colton_442.92500  442.925  447.925 High      4  90 -  Free  Normal  -      107.2  25
+ 111   FRS_1            462.5625 462.5625 Low       8  90 -  Free  Normal  -      -      12.5
+ 112   FRS_2            462.5875 462.5875 Low       8  90 -  Free  Normal  -      -      12.5
+ 113   FRS_3            462.6125 462.6125 Low       8  90 -  Free  Normal  -      -      12.5
+ 114   FRS_4            462.6375 462.6375 Low       8  90 -  Free  Normal  -      -      12.5
+ 115   FRS_5            462.6675 462.6675 Low       8  90 -  Free  Normal  -      -      12.5
+ 116   FRS_6            462.6875 462.6875 Low       8  90 -  Free  Normal  -      -      12.5
+ 117   FRS_7            462.7125 462.7125 Low       8  90 -  Free  Normal  -      -      12.5
+ 118   FRS_8_(IS)       467.5625 467.5625 Low       8  90 -  Free  Normal  -      -      12.5
+ 119   FRS_9_(IS)       467.5875 467.5875 Low       8  90 -  Free  Normal  -      -      12.5
+ 120   FRS_10_(IS)      467.6125 467.6125 Low       8  90 -  Free  Normal  -      -      12.5
+ 121   FRS_11_(IS)      467.6375 467.6375 Low       8  90 -  Free  Normal  -      -      12.5
+ 122   FRS_12_(IS)      467.6625 467.6625 Low       8  90 -  Free  Normal  -      -      12.5
+ 123   FRS_13_(IS)      467.6875 467.6875 Low       8  90 -  Free  Normal  -      -      12.5
+ 124   FRS_14_(IS)      467.7125 467.7125 Low       8  90 -  Free  Normal  -      -      12.5
+ 125   GMRS_1_(15)        462.55   462.55 High      9  90 -  Free  Normal  -      -      20
+ 126   GMRS_2_(16)       462.575  462.575 High      9  90 -  Free  Normal  -      -      20
+ 127   GMRS_3_(17)         462.6    462.6 High      9  90 -  Free  Normal  -      -      20
+ 128   GMRS_4_(18)       462.625  462.625 High      9  90 -  Free  Normal  -      -      20
+ 129   GMRS_5_(19)        462.65   462.65 High      9  90 -  Free  Normal  -      -      20
+ 130   GMRS_6_(20)       462.675  462.675 High      9  90 -  Free  Normal  -      -      20
+ 131   GMRS_7_(21)         462.7    462.7 High      9  90 -  Free  Normal  -      -      20
+ 132   GMRS_8_(22)       462.725  462.725 High      9  90 -  Free  Normal  -      -      20
 
 # Table of digital channels.
 # 1) Channel number: 1-1000
@@ -154,22 +154,22 @@ Analog Name             Receive  Transmit Power  Scan TOT RO Admit Squelch RxTon
 # 12) Receive group list: - or index in Grouplist table
 # 13) Contact for transmit: - or index in Contacts table
 Digital Name             Receive  Transmit Power  Scan TOT RO Admit Color Slot RxGL TxContact
-  117   SP_U01_441.000      441.0    441.0 High      6  90 -  Color 1        1 -       46   # Simplex 99
-  118   SP_U02_446.5        446.5    446.5 High      6  90 -  Color 1        1 -       46   # Simplex 99
-  119   SP_U03_446.075    446.075  446.075 High      6  90 -  Color 1        1 -       46   # Simplex 99
-  120   SP_U04_433.45      433.45   433.45 High      6  90 -  Color 1        1 -       46   # Simplex 99
-  121   SP_U05_430.4125  430.4125 430.4125 Low       6  90 -  Color 1        1 -       46   # Simplex 99
-  122   SP_U06_439.4125  439.4125 439.4125 Low       6  90 -  Color 1        1 -       46   # Simplex 99
-  123   SP_U07_430.425    430.425  430.425 Low       6  90 -  Color 1        1 -       46   # Simplex 99
-  124   SP_U08_439.425    439.425  439.425 Low       6  90 -  Color 1        1 -       46   # Simplex 99
-  125   R_U09_430.4375   430.4375 439.4375 Low       7  90 -  Color 1        1 -        5   # Local 1
-  126   R_U10_430.450      430.45   439.45 Low       7  90 -  Color 1        1 -        5   # Local 1
-  127   R_U11_430.4625   430.4625 439.4625 Low       7  90 -  Color 1        1 -        5   # Local 1
-  128   R_U12_430.475     430.475  439.475 Low       7  90 -  Color 1        1 -        5   # Local 1
-  129   R_U09R_430.4375  439.4375 430.4375 Low       7  90 -  Color 1        1 -        5   # Local 1
-  130   R_U10R_430.450     439.45   430.45 Low       7  90 -  Color 1        1 -        5   # Local 1
-  131   R_U11R_430.4625  439.4625 430.4625 Low       7  90 -  Color 1        1 -        5   # Local 1
-  132   R_U12R_430.475    439.475  430.475 Low       7  90 -  Color 1        1 -        5   # Local 1
+  28    SP_U01_441.000      441.0    441.0 High      6  90 -  Color 1        1 -       46   # Simplex 99
+  29    SP_U02_446.5        446.5    446.5 High      6  90 -  Color 1        1 -       46   # Simplex 99
+  30    SP_U03_446.075    446.075  446.075 High      6  90 -  Color 1        1 -       46   # Simplex 99
+  31    SP_U04_433.45      433.45   433.45 High      6  90 -  Color 1        1 -       46   # Simplex 99
+  32    SP_U05_430.4125  430.4125 430.4125 Low       6  90 -  Color 1        1 -       46   # Simplex 99
+  33    SP_U06_439.4125  439.4125 439.4125 Low       6  90 -  Color 1        1 -       46   # Simplex 99
+  34    SP_U07_430.425    430.425  430.425 Low       6  90 -  Color 1        1 -       46   # Simplex 99
+  35    SP_U08_439.425    439.425  439.425 Low       6  90 -  Color 1        1 -       46   # Simplex 99
+  103   R_U09_430.4375   430.4375 439.4375 Low       7  90 -  Color 1        1 -        5   # Local 1
+  104   R_U10_430.450      430.45   439.45 Low       7  90 -  Color 1        1 -        5   # Local 1
+  105   R_U11_430.4625   430.4625 439.4625 Low       7  90 -  Color 1        1 -        5   # Local 1
+  106   R_U12_430.475     430.475  439.475 Low       7  90 -  Color 1        1 -        5   # Local 1
+  107   R_U09R_430.4375  439.4375 430.4375 Low       7  90 -  Color 1        1 -        5   # Local 1
+  108   R_U10R_430.450     439.45   430.45 Low       7  90 -  Color 1        1 -        5   # Local 1
+  109   R_U11R_430.4625  439.4625 430.4625 Low       7  90 -  Color 1        1 -        5   # Local 1
+  110   R_U12R_430.475    439.475  430.475 Low       7  90 -  Color 1        1 -        5   # Local 1
   133   WA_2_BCB           443.85   448.85 High     12  90 -  Color 2        2    2     2   # Washington 2
   134   WA_1_BCB           443.85   448.85 High     12  90 -  Color 2        1    2     3   # Washington 1
   135   Parrot_1_BCB       443.85   448.85 High     12  90 -  Color 2        1    2     7   # Parrot 1
@@ -1199,16 +1199,16 @@ Grouplist  Name             Contacts
 # 6) List of channels: numbers and ranges (N-M) separated by comma
 Scanlist Name             PCh1 PCh2 TxCh Channels
    1     Longview_WA_35mi Sel  -    Last 1-19
-   2     Longview_WA_36mi Sel  -    Last 1-20
+   2     Longview_WA_36mi Sel  -    Last 1-19,36
    3     Longview_WA_UHF_ Sel  -    Last 1-19
-   4     Portland_OR_UHF_ Sel  -    Last 21-51
-   5     Simplex_A_UHF    Sel  -    Last 87-94
-   6     Simplex_D_UHF    Sel  -    Last 117-124
-   7     Simplex_DR_UHF   Sel  -    Last 125-132
-   8     UL_FRS_NBFM      Sel  -    Last 95-108
-   9     UL_GMRS          Sel  -    Last 109-116
-   10    Simplex_Scan     Sel  -    Last 117-124,95-116,87
-   11    UL_Scan          Sel  -    Last 95-116
+   4     Portland_OR_UHF_ Sel  -    Last 37-67
+   5     Simplex_A_UHF    Sel  -    Last 20-27
+   6     Simplex_D_UHF    Sel  -    Last 28-35
+   7     Simplex_DR_UHF   Sel  -    Last 103-110
+   8     UL_FRS_NBFM      Sel  -    Last 111-124
+   9     UL_GMRS          Sel  -    Last 125-132
+   10    Simplex_Scan     Sel  -    Last 28-35,111-132,20
+   11    UL_Scan          Sel  -    Last 111-132
    12    BC:Whisler/Black Sel  -    Last 133-148
    13    BC:NewWstmnstr   Sel  -    Last 149-164
    14    BC:Vancouver/Sey Sel  -    Last 165-180
@@ -1252,14 +1252,14 @@ Scanlist Name             PCh1 PCh2 TxCh Channels
 # 3) List of channels: numbers and ranges (N-M) separated by comma
 Zone  Name             Channels
   1    Longview_WA_35mi 1-16
-  2    Simplex_A_UHF    87-94
-  3    Simplex_D_UHF    117-124
+  2    Simplex_A_UHF    20-27
+  3    Simplex_D_UHF    28-35
   4    Longview_WA_36mi 1-16
   5    Longview_WA_UHF_ 1-16
-  6    Portland_OR_UHF_ 21-36
-  7    Simplex_DR_UHF   125-132
-  8    UL_FRS_NBFM      95-108
-  9    UL_GMRS          109-116
+  6    Portland_OR_UHF_ 37-52
+  7    Simplex_DR_UHF   103-110
+  8    UL_FRS_NBFM      111-124
+  9    UL_GMRS          125-132
   10   BC:Whisler/Black 133-148
   11   BC:NewWstmnstr   149-164
   12   BC:Vancouver/Sey 165-180

--- a/tests/test_dmrconfig.py
+++ b/tests/test_dmrconfig.py
@@ -18,8 +18,7 @@ default_dmrconfig_path = files(dzcb.data) / "dmrconfig"
     ),
 )
 def test_dmrconfig_templates(complex_codeplug, template):
-    table = dzcb.output.dmrconfig.Table(complex_codeplug)
-    assert dzcb.output.dmrconfig.Dmrconfig_Codeplug(table, template).render_template()
+    assert dzcb.output.dmrconfig.Dmrconfig_Codeplug.from_codeplug(complex_codeplug, template=template).render_template()
 
 
 @pytest.fixture
@@ -75,8 +74,8 @@ def test_dmrconfig_contact_integrity(same_contact_both_timeslots_codeplug, templ
     exp_channel_names = ("CT 1 RP", "CT 2 RP")
     assert tuple(ch.name for ch in exp_cp.channels) == exp_channel_names
 
-    dmrconfig_cp = dzcb.output.dmrconfig.Dmrconfig_Codeplug(
-        table=dzcb.output.dmrconfig.Table(codeplug=exp_cp, include_docs=False),
+    dmrconfig_cp = dzcb.output.dmrconfig.Dmrconfig_Codeplug.from_codeplug(
+        codeplug=exp_cp,
         template=template_filter,
     )
 


### PR DESCRIPTION
Clean up some mutable kludge because I felt bad just adding more kludge to `CodeplugIndexLookup`.

Removed the weird template attribute carrying when creating subtables in `Dmrconfig_Codeplug`. Now subtables are a straight up evolution of the `Table`. Create an alternate constructor `from_codeplug` that also accepts a template and will create the root table correctly before the `Dmrconfig_Codeplug` is initialized.

Added some weird filtering into `CodeplugIndexLookup` very similar to the contacts-by-name patch. The new channel filtering prefers channels in the order they appear in the zone list when the number of channels exceeds the limit given by the radio. Create the channel lists and indexes based on the _channels_filtered sequence in the index (instead of the codeplug).