### PR TITLE
Allow invalid tone

### DIFF
--- a/src/dzcb/k7abd.py
+++ b/src/dzcb/k7abd.py
@@ -37,6 +37,7 @@ from dzcb.model import (
     Talkgroup,
     Zone,
 )
+import dzcb.tone
 
 
 logger = logging.getLogger(__name__)
@@ -321,6 +322,10 @@ def Codeplug_from_k7abd(input_dir):
     talkgroups = {}
     all_talkgroups_by_name = {}
     total_files = 0
+    if not dzcb.tone.REQUIRE_VALID_TONE:
+        logger.warning(
+            "REQUIRE_VALID_TONE=0: resulting codeplug files may contain invalid entries"
+        )
     for p in sorted(d.glob("Analog__*.csv")):
         update_zones_channels(
             zones, Analog_from_csv(p.read_text().splitlines()), log_filename=p

--- a/src/dzcb/model.py
+++ b/src/dzcb/model.py
@@ -159,6 +159,14 @@ class Power(ConvertibleEnum):
             "No known powers are allowed {!r} from {!r}".format(self, allowed_powers)
         )
 
+    @classmethod
+    def from_any(cls, v):
+        """Passable as an attr converter."""
+        if isinstance(v, str):
+            # use title case string
+            v = v.title()
+        return super(Power, cls).from_any(v)
+
 
 class Bandwidth(ConvertibleEnum):
     _125 = "12.5"

--- a/src/dzcb/model.py
+++ b/src/dzcb/model.py
@@ -234,9 +234,13 @@ class Channel:
 
 def _tone_validator(instance, attribute, value):
     if value is not None and value not in dzcb.tone.VALID_TONES:
-        raise ValueError(
-            "field {!r} has unknown tone {!r}".format(attribute.name, value)
+        message = "field {!r} for {} has unknown tone {!r}".format(
+            attribute.name, instance.name, value
         )
+        if dzcb.tone.REQUIRE_VALID_TONE:
+            raise ValueError(message)
+        else:
+            logger.warning(message)
 
 
 def _tone_converter(value):

--- a/src/dzcb/tone.py
+++ b/src/dzcb/tone.py
@@ -1,5 +1,11 @@
 """All valid PL / DCS tones"""
 
+from .util import getenv_bool
+
+# set REQUIRE_VALID_TONE=0 in the environment to write non-valid tones
+# into codeplug output files
+REQUIRE_VALID_TONE = getenv_bool("REQUIRE_VALID_TONE", default=True)
+
 VALID_TONES = [
     "67.0",
     "69.3",

--- a/src/dzcb/util.py
+++ b/src/dzcb/util.py
@@ -1,0 +1,28 @@
+import os
+
+
+STR_TO_BOOL = {
+    "false": False,
+    "no": False,
+    "off": False,
+    "0": False,
+    0: False,
+    "true": True,
+    "yes": True,
+    "on": True,
+    "1": True,
+    1: True,
+}
+
+
+def getenv_bool(var_name, default=False):
+    """
+    Retrieve the given environment variable as a bool.
+
+    Will use the text translation table STR_TO_BOOL to facilitate the conversion
+    so that "yes"/"no" and "on"/"off" can also be used.
+    """
+    val = os.environ.get(var_name, None)
+    if val is None:
+        return default
+    return STR_TO_BOOL[val.lower()]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,38 @@
+import pytest
+
+import dzcb.util
+
+
+ENV_VAR_NAME = "TEST_UTIL_ENVVAR"
+
+
+@pytest.fixture(
+    params=[
+        ("yes", True),
+        ("on", True),
+        (0, False),
+        ("no", False),
+        ("off", False),
+        (None, None),  # should use default
+        ("foo", KeyError),  # should use default
+    ]
+)
+def exp_env_bool(request, monkeypatch):
+    env_value, exp_bool_value = request.param
+    if env_value is not None:
+        monkeypatch.setenv(ENV_VAR_NAME, env_value)
+    return exp_bool_value
+
+
+@pytest.mark.parametrize("default", [True, False])
+def test_getenv_bool(exp_env_bool, default):
+    if isinstance(exp_env_bool, type) and issubclass(exp_env_bool, Exception):
+        with pytest.raises(exp_env_bool):
+            _ = dzcb.util.getenv_bool(ENV_VAR_NAME, default=default)
+        return
+
+    val = dzcb.util.getenv_bool(ENV_VAR_NAME, default=default)
+    if exp_env_bool is None:
+        assert val is default
+    else:
+        assert val is exp_env_bool


### PR DESCRIPTION
Address #76 by allowing the user to specify `REQUIRE_VALID_TONE=0` in the environment when generating the codeplug files.