### PR TITLE
repeaterbook: skip records with invalid coordinates

### DIFF
--- a/src/dzcb/repeaterbook.py
+++ b/src/dzcb/repeaterbook.py
@@ -120,7 +120,20 @@ def filter_repeaters(repeaters, zone):
         if radius:
             # repeater must be within radius of poi
             repeater_coords = (r["Lat"], r["Long"])
-            distance = geopy.distance.distance(poi_coords, repeater_coords)
+            try:
+                distance = geopy.distance.distance(poi_coords, repeater_coords)
+            except ValueError:
+                repeater_id = (
+                    r.get("State ID", "Unknown state"),
+                    r.get("Rptr ID", "Unknown repeater"),
+                )
+                logger.warning(
+                    "Ignore repeater {!r} with bogus coordinates: {!r}".format(
+                        repeater_id,
+                        repeater_coords,
+                    )
+                )
+                continue
             if getattr(distance, dunit) > radius:
                 continue
         if bands:


### PR DESCRIPTION
We don't really have control over these and they wouldn't show
up in a prox listing anyway, so just log and skip over them.

fixes #78

@mkaylor this fixes at least one of your issues.