### PR TITLE
Uniquify zone names (and warn about it)

### DIFF
--- a/src/dzcb/k7abd.py
+++ b/src/dzcb/k7abd.py
@@ -38,6 +38,7 @@ from dzcb.model import (
     Zone,
 )
 import dzcb.tone
+from dzcb.util import unique_name
 
 
 logger = logging.getLogger(__name__)
@@ -97,7 +98,7 @@ def Codeplug_from_zone_dicts(zone_dicts):
     def update_static_talkgroups(ch):
         contacts.update(ch.static_talkgroups)
         grouplist = GroupList(
-            name="{} TGS".format(ch.code),
+            name="{} TGS".format(ch.code or ch.name[:5]),
             contacts=ch.static_talkgroups,
         )
         grouplists.append(grouplist)
@@ -126,9 +127,7 @@ def Codeplug_from_zone_dicts(zone_dicts):
                 ch = attr.evolve(ch, dedup_key=ch._dedup_key + 1)
             all_channels[ch.short_name] = ch
             updated_channels.append(ch)
-        scanlists.append(
-            attr.evolve(zscanlist, channels=updated_channels)
-        )
+        scanlists.append(attr.evolve(zscanlist, channels=updated_channels))
         zones.append(
             Zone(
                 name=zname,
@@ -308,8 +307,8 @@ def update_zones_channels(zones_dict, in_zones, log_filename=None):
     :param log_filename: used for logging only
     """
     _log_zones_channels(in_zones, log_filename)
-    # XXX: instead, consider combining channels from same-named zones in different CSV files?
-    zones_dict.update(in_zones)
+    for zname, zchannels in in_zones.items():
+        zones_dict[unique_name(zname, zones_dict)] = zchannels
 
 
 def Codeplug_from_k7abd(input_dir):

--- a/src/dzcb/model.py
+++ b/src/dzcb/model.py
@@ -15,6 +15,7 @@ import dzcb.data
 import dzcb.exceptions
 import dzcb.munge
 import dzcb.tone
+from dzcb.util import unique_name
 
 # XXX: i hate this
 NAME_MAX = 16
@@ -845,14 +846,16 @@ class Codeplug:
         if static_talkgroup_order is None:
             static_talkgroup_order = []
         zones = list(self.zones)
+        zone_names = set(z.name for z in zones)
         channels = []
         exp_scanlists = []
         for ch in self.channels:
             if not isinstance(ch, DigitalChannel) or not ch.static_talkgroups:
                 channels.append(ch)
                 continue
+            exp_zone_name = unique_name(ch.short_name, zone_names)
             zscanlist = ScanList(
-                name=ch.short_name,
+                name=exp_zone_name,
                 channels=[],
             )
             zone_channels = ch.from_talkgroups(
@@ -862,7 +865,7 @@ class Codeplug:
             exp_scanlists.append(attr.evolve(zscanlist, channels=zone_channels))
             zones.append(
                 Zone(
-                    name=ch.short_name,
+                    name=exp_zone_name,
                     channels_a=zone_channels,
                     channels_b=zone_channels,
                 )

--- a/src/dzcb/util.py
+++ b/src/dzcb/util.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 
@@ -15,6 +16,9 @@ STR_TO_BOOL = {
 }
 
 
+logger = logging.getLogger(__name__)
+
+
 def getenv_bool(var_name, default=False):
     """
     Retrieve the given environment variable as a bool.
@@ -26,3 +30,28 @@ def getenv_bool(var_name, default=False):
     if val is None:
         return default
     return STR_TO_BOOL[val.lower()]
+
+
+def unique_name(name, existing_names, fmt="{} {}"):
+    """
+    Create a unique name by appending numbers.
+
+    :param name: the base name that numbers are added to
+    :param existing_names: container of names that are taken (prefer set or dict)
+    :param fmt: how to format the new name, default "{} {}"
+        expects 2 positional args in a new-style format string
+    :return: a name based on `name` that doesn't exist in `existing_names`.
+    """
+    ix = 0
+    maybe_unique_name = name
+    while maybe_unique_name in existing_names:
+        maybe_unique_name = fmt.format(name, ix)
+        ix += 1
+    if maybe_unique_name != name:
+        logger.warning(
+            "Deduping name {!r} -> {!r}. Consider using unique names for clarity.".format(
+                name,
+                maybe_unique_name,
+            ),
+        )
+    return maybe_unique_name


### PR DESCRIPTION
Attempt to dedupe zone names by appending a
number when pulling k7abd zones or expanding
static talkgroups (although possibly less
of an issue due to channel deduping that
already exists)

Fixes #80