### PR TITLE
SeattleDMR fallback: use a cached copy

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/codeplug/mirror/Digital-Repeaters__SeattleDMR_2022_03_31.csv
+++ b/codeplug/mirror/Digital-Repeaters__SeattleDMR_2022_03_31.csv
@@ -1,0 +1,7 @@
+"Zone Name","Comment","Power","RX Freq","TX Freq","Color Code","Audio Test 2","Baynet 2","BEARS 1","BEARS 2","King County","Link 1","Link 2","Link 3","Link 4","Link 5","Link 6","Local 1","Local 2","Parrot 1","PNW Rgnl 2","Puget Sound","Seattle 1","Seattle 2","TAC 313-2","Washington 1","Washington 2"
+"BEARS W.Tiger;BWT",,"High",442.075,447.075,2,2,2,1,2,2,1,2,1,2,1,2,1,2,1,2,2,1,2,2,1,2
+"Seattle/Central;SCE",,"High",440.775,445.775,2,2,2,1,2,2,1,2,1,2,1,2,1,2,1,2,2,1,2,2,1,2
+"Seattle/North;LFP",,"High",441.025,446.025,2,2,2,1,2,2,1,2,1,2,1,2,1,2,1,2,2,1,2,2,1,2
+"Seattle/West;SWE",,"High",440.975,445.975,2,2,2,1,2,2,1,2,1,2,1,2,1,2,1,2,2,1,2,2,1,2
+"Buck Mt.;BUC",,"High",440.7625,445.7625,2,2,2,1,2,2,1,2,1,2,1,2,1,2,1,2,2,1,2,2,1,2
+"SeattleDMR;HOT",,"Low",430.4375,439.4375,2,2,2,1,2,2,1,2,1,2,1,2,1,2,1,2,2,1,2,2,1,2

--- a/codeplug/mirror/Talkgroups__SeattleDMR_2022_03_31.csv
+++ b/codeplug/mirror/Talkgroups__SeattleDMR_2022_03_31.csv
@@ -1,0 +1,17 @@
+King County,333153
+Seattle 1,803153
+Seattle 2,813153
+Puget Sound,31532
+Link 1,8801
+Link 2,8802
+Link 3,8803
+Link 4,8804
+Link 5,8805
+Link 6,8806
+Link 7,8807
+Link 8,8808
+Link 9,8809
+Link 10,8810
+BEARS 1,312488
+BEARS 2,312547
+TAC 8-2,8958

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     package_data={'dzcb': ['data/*.json', 'data/*.csv', 'data/k7abd/*.csv', 'data/farnsworth/*.json', 'data/dmrconfig/*.conf']},
     packages=setuptools.find_packages('src'),
     py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],
-    python_requires='>=3.6,<4',
+    python_requires='>=3.7,<4',
     setup_requires=[
         'setuptools_scm >= 3.3',
     ],

--- a/src/dzcb/log.py
+++ b/src/dzcb/log.py
@@ -21,7 +21,8 @@ def change_log_level(to):
 
 def ltrim_to_delimiter(d):
     def _ltrim_to_delimiter(r):
-        r.args = (r.args[0].partition(d)[2], *r.args[1:])
+        if r.args:
+            r.args = (r.args[0].partition(d)[2], *r.args[1:])
         return True
 
     return _ltrim_to_delimiter
@@ -29,7 +30,8 @@ def ltrim_to_delimiter(d):
 
 def keep_to_delimiter(d):
     def _keep_to_delimiter(r):
-        r.args = (r.args[0].partition(d)[0], *r.args[1:])
+        if r.args:
+            r.args = (r.args[0].partition(d)[0], *r.args[1:])
         return True
 
     return _keep_to_delimiter

--- a/src/dzcb/seattledmr.py
+++ b/src/dzcb/seattledmr.py
@@ -8,20 +8,35 @@ import requests
 
 logger = logging.getLogger(__name__)
 
+
 SEATTLE_DMR_REPEATERS = (
-    "http://seattledmr.org/ConfigBuilder/Digital-Repeaters-Seattle-addon.csv"
+    "http://seattledmr.org/ConfigBuilder/Digital-Repeaters-Seattle-addon.csv",
+    "https://github.com/mycodeplug/dzcb/raw/042788686ad192b3d7bff4da1d8c0fbca251cb6f/codeplug/mirror/Digital-Repeaters__SeattleDMR_2022_03_31.csv"
 )
 SEATTLE_DMR_TALKGROUPS = (
-    "http://seattledmr.org/ConfigBuilder/Talkgroups-Seattle-addon.csv"
+    "http://seattledmr.org/ConfigBuilder/Talkgroups-Seattle-addon.csv",
+    "https://github.com/mycodeplug/dzcb/raw/042788686ad192b3d7bff4da1d8c0fbca251cb6f/codeplug/mirror/Talkgroups__SeattleDMR_2022_03_31.csv"
 )
 REPEATER_FILENAME = "Digital-Repeaters__SeattleDMR.csv"
 TALKGROUPS_FILENAME = "Talkgroups__SeattleDMR.csv"
 
 
 def cache_repeaters(output_dir):
-    repeaters = requests.get(SEATTLE_DMR_REPEATERS)
+    for dr_url in SEATTLE_DMR_REPEATERS:
+        try:
+            repeaters = requests.get(dr_url)
+            if repeaters.status_code < 300:
+                break
+        except requests.ConnectionError:
+            pass
     repeaters.raise_for_status()
-    talkgroups = requests.get(SEATTLE_DMR_TALKGROUPS)
+    for tg_url in SEATTLE_DMR_TALKGROUPS:
+        try:
+            talkgroups = requests.get(tg_url)
+            if talkgroups.status_code < 300:
+                break
+        except requests.ConnectionError:
+            pass
     talkgroups.raise_for_status()
     outpath = Path(output_dir)
     rp_out = outpath / REPEATER_FILENAME

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,8 @@ commands = python {toxinidir}/codeplug/generate_all.py
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
+    3.11: py311


### PR DESCRIPTION
Stop the bleeding and allow codeplugs to be generated again. See issue #88 for ultimate resolution to SeattleDMR woes.