### PR TITLE
Update requests to newer version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
         'attrs',
         'geopy==2.1.0',
         'importlib-resources',
-        'requests~=2.24.0',
+        'requests~=2.31',
     ],
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
Using requests~=2.24.0 causes urllib3 to be downgraded to urllib3 1.25.11.  Subsequently, attempts to import urllib3 fail with:

    ModuleNotFoundError: No module named 'urllib3.packages.six.moves'